### PR TITLE
Fix: Handle Mint record type views

### DIFF
--- a/typescript/api/services/CloudDatastreamService.ts
+++ b/typescript/api/services/CloudDatastreamService.ts
@@ -199,7 +199,7 @@ export module Services {
       .flatMap(form => {
         const reqs = [];
         record.metaMetadata.attachmentFields = form != undefined ? form.attachmentFields : [];
-        _.each(form.attachmentFields, async (attField) => {
+        _.each(record.metaMetadata.attachmentFields, async (attField) => {
           const oldAttachments = record.metadata[attField];
           const newAttachments = newMetadata[attField];
           const removeIds = [];

--- a/typescript/api/services/CloudDatastreamService.ts
+++ b/typescript/api/services/CloudDatastreamService.ts
@@ -198,7 +198,7 @@ export module Services {
       return FormsService.getFormByName(record.metaMetadata.form, true)
       .flatMap(form => {
         const reqs = [];
-        record.metaMetadata.attachmentFields = form.attachmentFields;
+        record.metaMetadata.attachmentFields = form != undefined ? form.attachmentFields : [];
         _.each(form.attachmentFields, async (attField) => {
           const oldAttachments = record.metadata[attField];
           const newAttachments = newMetadata[attField];


### PR DESCRIPTION
Fixes issue with attachmentFields that prevents the new Mint records with the "generate-view-only" form type from being updated.